### PR TITLE
Harden review auth, dedupe nutrition schema, gate admin queries

### DIFF
--- a/convex/cafes.ts
+++ b/convex/cafes.ts
@@ -70,10 +70,7 @@ export const create = mutation({
     uploadSecret: v.optional(v.string()),
   },
   handler: async (ctx, { name, slug, imageStorageId, rank, uploadSecret }) => {
-    const expectedSecret = process.env.CONVEX_UPLOAD_SECRET;
-    if (expectedSecret && uploadSecret !== expectedSecret) {
-      throw new Error("Unauthorized: Invalid upload secret");
-    }
+    verifyUploadSecret(uploadSecret);
 
     const existing = await ctx.db
       .query("cafes")
@@ -102,11 +99,7 @@ export const updateImage = mutation({
     uploadSecret: v.optional(v.string()),
   },
   handler: async (ctx, { cafeId, storageId, uploadSecret }) => {
-    // Verify upload secret for protected operations
-    const expectedSecret = process.env.CONVEX_UPLOAD_SECRET;
-    if (expectedSecret && uploadSecret !== expectedSecret) {
-      throw new Error("Unauthorized: Invalid upload secret");
-    }
+    verifyUploadSecret(uploadSecret);
 
     await ctx.db.patch(cafeId, {
       imageStorageId: storageId,

--- a/convex/cafes.ts
+++ b/convex/cafes.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
+import { verifyUploadSecret } from "./uploadSecret";
 
 export const list = query({
   args: {},
@@ -46,8 +47,10 @@ export const getById = query({
 });
 
 export const getAllWithImages = query({
-  args: {},
-  handler: async (ctx) => {
+  args: { uploadSecret: v.optional(v.string()) },
+  handler: async (ctx, { uploadSecret }) => {
+    verifyUploadSecret(uploadSecret);
+
     const cafes = await ctx.db
       .query("cafes")
       .filter((q) => q.neq(q.field("imageStorageId"), undefined))

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -4,6 +4,7 @@ import { v } from "convex/values";
 import { Webhook } from "svix";
 import { internal } from "./_generated/api";
 import { httpAction, mutation, query } from "./_generated/server";
+import { verifyUploadSecret } from "./uploadSecret";
 
 const http = httpRouter();
 
@@ -61,11 +62,7 @@ async function validateRequest(req: Request): Promise<WebhookEvent | null> {
 export const generateUploadUrl = mutation({
   args: { uploadSecret: v.optional(v.string()) },
   handler: async (ctx, { uploadSecret }) => {
-    // Verify upload secret for protected operations
-    const expectedSecret = process.env.CONVEX_UPLOAD_SECRET;
-    if (expectedSecret && uploadSecret !== expectedSecret) {
-      throw new Error("Unauthorized: Invalid upload secret");
-    }
+    verifyUploadSecret(uploadSecret);
 
     return await ctx.storage.generateUploadUrl();
   },

--- a/convex/nutritionsValidator.ts
+++ b/convex/nutritionsValidator.ts
@@ -1,0 +1,35 @@
+import { type Infer, v } from "convex/values";
+
+/**
+ * Single source of truth for product nutrition fields.
+ *
+ * Reused by the Convex schema (`convex/schema.ts`), the `upsertProduct`
+ * mutation args (`convex/products.ts`), and the shared `Nutritions` TypeScript
+ * type (`shared/nutritions.ts`). Add or change a nutrition field here only.
+ */
+export const nutritionsValidator = v.object({
+  servingSize: v.optional(v.number()),
+  servingSizeUnit: v.optional(v.string()),
+  calories: v.optional(v.number()),
+  caloriesUnit: v.optional(v.string()),
+  carbohydrates: v.optional(v.number()),
+  carbohydratesUnit: v.optional(v.string()),
+  sugar: v.optional(v.number()),
+  sugarUnit: v.optional(v.string()),
+  protein: v.optional(v.number()),
+  proteinUnit: v.optional(v.string()),
+  fat: v.optional(v.number()),
+  fatUnit: v.optional(v.string()),
+  transFat: v.optional(v.number()),
+  transFatUnit: v.optional(v.string()),
+  saturatedFat: v.optional(v.number()),
+  saturatedFatUnit: v.optional(v.string()),
+  natrium: v.optional(v.number()),
+  natriumUnit: v.optional(v.string()),
+  cholesterol: v.optional(v.number()),
+  cholesterolUnit: v.optional(v.string()),
+  caffeine: v.optional(v.number()),
+  caffeineUnit: v.optional(v.string()),
+});
+
+export type Nutritions = Infer<typeof nutritionsValidator>;

--- a/convex/products.ts
+++ b/convex/products.ts
@@ -557,6 +557,28 @@ export const deleteProduct = mutation({
       return { success: false, error: "Product not found" };
     }
 
+    // Delete associated reviews (and their images) first. Otherwise the
+    // reviews are orphaned: getUserReviews resolves their `product` to null,
+    // and ReviewInUserPage then queries cafes.getById with an undefined
+    // cafeId, crashing the profile page.
+    const reviews = await ctx.db
+      .query("reviews")
+      .withIndex("by_product", (q) => q.eq("productId", productId))
+      .collect();
+
+    for (const review of reviews) {
+      if (review.imageStorageIds) {
+        for (const imageId of review.imageStorageIds) {
+          try {
+            await ctx.storage.delete(imageId);
+          } catch (_error) {
+            // Storage cleanup failure is not critical for product deletion
+          }
+        }
+      }
+      await ctx.db.delete(review._id);
+    }
+
     // Clean up associated image
     if (product.imageStorageId) {
       try {
@@ -569,7 +591,11 @@ export const deleteProduct = mutation({
     // Delete the product
     await ctx.db.delete(productId);
 
-    return { success: true, imageCleaned: !!product.imageStorageId };
+    return {
+      success: true,
+      imageCleaned: !!product.imageStorageId,
+      reviewsDeleted: reviews.length,
+    };
   },
 });
 

--- a/convex/products.ts
+++ b/convex/products.ts
@@ -8,6 +8,13 @@ import {
   type QueryCtx,
   query,
 } from "./_generated/server";
+import { nutritionsValidator } from "./nutritionsValidator";
+import { verifyUploadSecret } from "./uploadSecret";
+
+// Field names derived from the validator so changes stay in one place.
+const NUTRITION_FIELDS = Object.keys(
+  nutritionsValidator.fields
+) as (keyof Nutritions)[];
 
 async function resolveImageUrl(
   ctx: QueryCtx,
@@ -68,7 +75,8 @@ export const search = query({
       return [];
     }
 
-    // Filter by cafe if specified
+    // Filter by cafe if specified. Both branches read only active products
+    // straight from an index instead of scanning the whole table.
     let products = cafeId
       ? await ctx.db
           .query("products")
@@ -78,7 +86,7 @@ export const search = query({
           .collect()
       : await ctx.db
           .query("products")
-          .filter((q) => q.eq(q.field("isActive"), true))
+          .withIndex("by_is_active_added_at", (q) => q.eq("isActive", true))
           .collect();
 
     // Filter by category if specified
@@ -125,12 +133,16 @@ export const getSuggestions = query({
       return [];
     }
 
-    const products = await ctx.db.query("products").collect();
+    // Read only active products from the index instead of scanning every
+    // product (including removed ones) on each keystroke.
+    const products = await ctx.db
+      .query("products")
+      .withIndex("by_is_active_added_at", (q) => q.eq("isActive", true))
+      .collect();
     const term = searchTerm.toLowerCase().replace(/\s+/g, "");
 
-    // Filter active products and search in name/nameEn
+    // Search in name/nameEn
     const matches = products
-      .filter((p) => p.isActive)
       .filter(
         (p) =>
           p.name.toLowerCase().replace(/\s+/g, "").includes(term) ||
@@ -181,43 +193,16 @@ function hasNutritionChanges(
   existing?: Nutritions,
   args?: Nutritions
 ): boolean {
+  // Neither side has nutrition data -> no change.
   if (!(existing || args)) {
     return false;
   }
-  if (!existing && args) {
-    return true;
-  }
-  if (existing && !args) {
-    return true;
-  }
+  // Exactly one side has data -> changed.
   if (!(existing && args)) {
-    return false;
+    return true;
   }
-
-  return (
-    existing.servingSize !== args.servingSize ||
-    existing.servingSizeUnit !== args.servingSizeUnit ||
-    existing.calories !== args.calories ||
-    existing.caloriesUnit !== args.caloriesUnit ||
-    existing.carbohydrates !== args.carbohydrates ||
-    existing.carbohydratesUnit !== args.carbohydratesUnit ||
-    existing.sugar !== args.sugar ||
-    existing.sugarUnit !== args.sugarUnit ||
-    existing.protein !== args.protein ||
-    existing.proteinUnit !== args.proteinUnit ||
-    existing.fat !== args.fat ||
-    existing.fatUnit !== args.fatUnit ||
-    existing.transFat !== args.transFat ||
-    existing.transFatUnit !== args.transFatUnit ||
-    existing.saturatedFat !== args.saturatedFat ||
-    existing.saturatedFatUnit !== args.saturatedFatUnit ||
-    existing.natrium !== args.natrium ||
-    existing.natriumUnit !== args.natriumUnit ||
-    existing.cholesterol !== args.cholesterol ||
-    existing.cholesterolUnit !== args.cholesterolUnit ||
-    existing.caffeine !== args.caffeine ||
-    existing.caffeineUnit !== args.caffeineUnit
-  );
+  // Both sides present -> compare every field.
+  return NUTRITION_FIELDS.some((field) => existing[field] !== args[field]);
 }
 
 function hasProductChanges(
@@ -331,32 +316,7 @@ export const upsertProduct = mutation({
     externalId: v.string(),
     externalUrl: v.string(),
     price: v.optional(v.number()),
-    nutritions: v.optional(
-      v.object({
-        servingSize: v.optional(v.number()),
-        servingSizeUnit: v.optional(v.string()),
-        calories: v.optional(v.number()),
-        caloriesUnit: v.optional(v.string()),
-        carbohydrates: v.optional(v.number()),
-        carbohydratesUnit: v.optional(v.string()),
-        sugar: v.optional(v.number()),
-        sugarUnit: v.optional(v.string()),
-        protein: v.optional(v.number()),
-        proteinUnit: v.optional(v.string()),
-        fat: v.optional(v.number()),
-        fatUnit: v.optional(v.string()),
-        transFat: v.optional(v.number()),
-        transFatUnit: v.optional(v.string()),
-        saturatedFat: v.optional(v.number()),
-        saturatedFatUnit: v.optional(v.string()),
-        natrium: v.optional(v.number()),
-        natriumUnit: v.optional(v.string()),
-        cholesterol: v.optional(v.number()),
-        cholesterolUnit: v.optional(v.string()),
-        caffeine: v.optional(v.number()),
-        caffeineUnit: v.optional(v.string()),
-      })
-    ),
+    nutritions: v.optional(nutritionsValidator),
     downloadImages: v.optional(v.boolean()),
     isActive: v.optional(v.boolean()), // Default to true if not specified
   },
@@ -574,8 +534,10 @@ export const updateImage = mutation({
 });
 
 export const getAllWithImages = query({
-  args: {},
-  handler: async (ctx) => {
+  args: { uploadSecret: v.optional(v.string()) },
+  handler: async (ctx, { uploadSecret }) => {
+    verifyUploadSecret(uploadSecret);
+
     const products = await ctx.db
       .query("products")
       .filter((q) => q.neq(q.field("imageStorageId"), undefined))

--- a/convex/products.ts
+++ b/convex/products.ts
@@ -499,11 +499,7 @@ export const updateImage = mutation({
     uploadSecret: v.optional(v.string()),
   },
   handler: async (ctx, { productId, storageId, uploadSecret }) => {
-    // Verify upload secret for protected operations
-    const expectedSecret = process.env.CONVEX_UPLOAD_SECRET;
-    if (expectedSecret && uploadSecret !== expectedSecret) {
-      throw new Error("Unauthorized: Invalid upload secret");
-    }
+    verifyUploadSecret(uploadSecret);
 
     // Get the current product to check for existing image
     const product = await ctx.db.get(productId);
@@ -554,11 +550,7 @@ export const deleteProduct = mutation({
     uploadSecret: v.optional(v.string()),
   },
   handler: async (ctx, { productId, uploadSecret }) => {
-    // Verify upload secret for protected operations
-    const expectedSecret = process.env.CONVEX_UPLOAD_SECRET;
-    if (expectedSecret && uploadSecret !== expectedSecret) {
-      throw new Error("Unauthorized: Invalid upload secret");
-    }
+    verifyUploadSecret(uploadSecret);
 
     const product = await ctx.db.get(productId);
     if (!product) {

--- a/convex/reviews.ts
+++ b/convex/reviews.ts
@@ -2,6 +2,8 @@ import { v } from "convex/values";
 import { api } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { mutation, type QueryCtx, query } from "./_generated/server";
+import { verifyUploadSecret } from "./uploadSecret";
+import { getCurrentUserOrThrow } from "./users";
 
 /**
  * Rating scale mapping for Korean labels
@@ -153,12 +155,15 @@ export const getUserReview = query({
 export const upsertReview = mutation({
   args: {
     productId: v.id("products"),
-    userId: v.string(),
     rating: v.number(),
     text: v.optional(v.string()),
     imageStorageIds: v.optional(v.array(v.id("_storage"))),
   },
   handler: async (ctx, args) => {
+    // Identity is derived from the authenticated session, never trusted from
+    // the client, to prevent impersonating or overwriting another user.
+    const user = await getCurrentUserOrThrow(ctx);
+    const userId = user._id;
     const now = Date.now();
 
     // Validate rating
@@ -177,7 +182,7 @@ export const upsertReview = mutation({
     const existingReview = await ctx.db
       .query("reviews")
       .withIndex("by_product", (q) => q.eq("productId", args.productId))
-      .filter((q) => q.eq(q.field("userId"), args.userId))
+      .filter((q) => q.eq(q.field("userId"), userId))
       .first();
 
     let reviewId: Id<"reviews">;
@@ -196,7 +201,7 @@ export const upsertReview = mutation({
       // Create new review
       reviewId = await ctx.db.insert("reviews", {
         productId: args.productId,
-        userId: args.userId,
+        userId,
         rating: args.rating,
         text: args.text,
         imageStorageIds: args.imageStorageIds,
@@ -221,16 +226,16 @@ export const upsertReview = mutation({
 export const deleteReview = mutation({
   args: {
     reviewId: v.id("reviews"),
-    userId: v.string(), // For authorization
   },
-  handler: async (ctx, { reviewId, userId }) => {
+  handler: async (ctx, { reviewId }) => {
+    const user = await getCurrentUserOrThrow(ctx);
     const review = await ctx.db.get(reviewId);
 
     if (!review) {
       throw new Error("Review not found");
     }
 
-    if (review.userId !== userId) {
+    if (review.userId !== user._id) {
       throw new Error("Unauthorized: Can only delete your own reviews");
     }
 
@@ -274,6 +279,8 @@ export const updateProductStats = mutation({
 export const generateUploadUrl = mutation({
   args: {},
   handler: async (ctx) => {
+    // Only authenticated users may obtain an upload URL for review photos.
+    await getCurrentUserOrThrow(ctx);
     return await ctx.storage.generateUploadUrl();
   },
 });
@@ -386,8 +393,10 @@ export const getById = query({
 });
 
 export const getAllWithImages = query({
-  args: {},
-  handler: async (ctx) => {
+  args: { uploadSecret: v.optional(v.string()) },
+  handler: async (ctx, { uploadSecret }) => {
+    verifyUploadSecret(uploadSecret);
+
     const reviews = await ctx.db
       .query("reviews")
       .filter((q) => q.neq(q.field("imageStorageIds"), undefined))

--- a/convex/reviews.ts
+++ b/convex/reviews.ts
@@ -375,11 +375,9 @@ export const getById = query({
     // Get cafe information
     const cafe = await ctx.db.get(product.cafeId);
 
-    // Get user information
-    const user = await ctx.db
-      .query("users")
-      .withIndex("by_id", (q) => q.eq("_id", review.userId as Id<"users">))
-      .unique();
+    // Get user information. review.userId stores the Convex users._id, so
+    // look it up directly (there is no `by_id` index to query through).
+    const user = await ctx.db.get(review.userId as Id<"users">);
 
     return {
       ...review,

--- a/convex/reviews.ts
+++ b/convex/reviews.ts
@@ -412,11 +412,7 @@ export const updateImages = mutation({
     uploadSecret: v.optional(v.string()),
   },
   handler: async (ctx, { reviewId, imageStorageIds, uploadSecret }) => {
-    // Verify upload secret for protected operations
-    const expectedSecret = process.env.CONVEX_UPLOAD_SECRET;
-    if (expectedSecret && uploadSecret !== expectedSecret) {
-      throw new Error("Unauthorized: Invalid upload secret");
-    }
+    verifyUploadSecret(uploadSecret);
 
     const now = Date.now();
 

--- a/convex/reviews.ts
+++ b/convex/reviews.ts
@@ -239,6 +239,18 @@ export const deleteReview = mutation({
       throw new Error("Unauthorized: Can only delete your own reviews");
     }
 
+    // Clean up the review's images (best-effort) before deleting it, matching
+    // the cleanup done in deleteProduct/deleteAccount.
+    if (review.imageStorageIds) {
+      for (const imageId of review.imageStorageIds) {
+        try {
+          await ctx.storage.delete(imageId);
+        } catch (_error) {
+          // Storage cleanup failure is not critical for review deletion
+        }
+      }
+    }
+
     await ctx.db.delete(reviewId);
 
     // Update product aggregation stats

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,5 +1,6 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
+import { nutritionsValidator } from "./nutritionsValidator";
 
 export default defineSchema({
   cafes: defineTable({
@@ -20,32 +21,7 @@ export default defineSchema({
     externalId: v.string(),
     externalUrl: v.string(),
     price: v.optional(v.number()),
-    nutritions: v.optional(
-      v.object({
-        servingSize: v.optional(v.number()),
-        servingSizeUnit: v.optional(v.string()),
-        calories: v.optional(v.number()),
-        caloriesUnit: v.optional(v.string()),
-        carbohydrates: v.optional(v.number()),
-        carbohydratesUnit: v.optional(v.string()),
-        sugar: v.optional(v.number()),
-        sugarUnit: v.optional(v.string()),
-        protein: v.optional(v.number()),
-        proteinUnit: v.optional(v.string()),
-        fat: v.optional(v.number()),
-        fatUnit: v.optional(v.string()),
-        transFat: v.optional(v.number()),
-        transFatUnit: v.optional(v.string()),
-        saturatedFat: v.optional(v.number()),
-        saturatedFatUnit: v.optional(v.string()),
-        natrium: v.optional(v.number()),
-        natriumUnit: v.optional(v.string()),
-        cholesterol: v.optional(v.number()),
-        cholesterolUnit: v.optional(v.string()),
-        caffeine: v.optional(v.number()),
-        caffeineUnit: v.optional(v.string()),
-      })
-    ),
+    nutritions: v.optional(nutritionsValidator),
     isActive: v.optional(v.boolean()), // Track if product is currently available on cafe website
     addedAt: v.number(),
     updatedAt: v.number(),
@@ -65,7 +41,7 @@ export default defineSchema({
     .index("by_is_active_added_at", ["isActive", "addedAt"]),
   reviews: defineTable({
     productId: v.id("products"),
-    userId: v.string(), // Clerk user ID
+    userId: v.string(), // Convex users._id (the review author's document id)
     rating: v.number(), // 1-5 scale (1=최악, 2=별로, 3=보통, 3.5=좋음, 4=추천, 4.5=강력추천, 5=최고)
     text: v.optional(v.string()), // Optional review text
     imageStorageIds: v.optional(v.array(v.id("_storage"))), // Up to 2 photos

--- a/convex/storage.ts
+++ b/convex/storage.ts
@@ -82,11 +82,7 @@ export const deleteStorageFile = mutation({
     uploadSecret: v.optional(v.string()),
   },
   handler: async (ctx, { storageId, uploadSecret }) => {
-    // Verify upload secret for protected operations
-    const expectedSecret = process.env.CONVEX_UPLOAD_SECRET;
-    if (expectedSecret && uploadSecret !== expectedSecret) {
-      throw new Error("Unauthorized: Invalid upload secret");
-    }
+    verifyUploadSecret(uploadSecret);
 
     try {
       await ctx.storage.delete(storageId);
@@ -110,11 +106,7 @@ export const deleteStorageFiles = mutation({
     uploadSecret: v.optional(v.string()),
   },
   handler: async (ctx, { storageIds, uploadSecret }) => {
-    // Verify upload secret for protected operations
-    const expectedSecret = process.env.CONVEX_UPLOAD_SECRET;
-    if (expectedSecret && uploadSecret !== expectedSecret) {
-      throw new Error("Unauthorized: Invalid upload secret");
-    }
+    verifyUploadSecret(uploadSecret);
 
     const results: Array<{
       success: boolean;

--- a/convex/storage.ts
+++ b/convex/storage.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import type { Id } from "./_generated/dataModel";
 import { mutation, query } from "./_generated/server";
+import { verifyUploadSecret } from "./uploadSecret";
 
 /**
  * Get storage files from the system with pagination
@@ -10,8 +11,11 @@ export const getAllStorageFiles = query({
   args: {
     cursor: v.optional(v.string()),
     limit: v.optional(v.number()),
+    uploadSecret: v.optional(v.string()),
   },
-  handler: async (ctx, { cursor, limit = 8000 }) => {
+  handler: async (ctx, { cursor, limit = 8000, uploadSecret }) => {
+    verifyUploadSecret(uploadSecret);
+
     // Ensure we don't exceed Convex limits
     const safeLimit = Math.min(limit, 8000);
 
@@ -41,8 +45,13 @@ export const getAllStorageFiles = query({
  * Get metadata for multiple storage files
  */
 export const getStorageMetadata = query({
-  args: { storageIds: v.array(v.id("_storage")) },
-  handler: async (ctx, { storageIds }) => {
+  args: {
+    storageIds: v.array(v.id("_storage")),
+    uploadSecret: v.optional(v.string()),
+  },
+  handler: async (ctx, { storageIds, uploadSecret }) => {
+    verifyUploadSecret(uploadSecret);
+
     const metadataPromises = storageIds.map(async (storageId) => {
       try {
         const metadata = await ctx.db.system.get(storageId);
@@ -142,8 +151,10 @@ export const deleteStorageFiles = mutation({
  * Get statistics about storage usage
  */
 export const getStorageStats = query({
-  args: {},
-  handler: async (ctx) => {
+  args: { uploadSecret: v.optional(v.string()) },
+  handler: async (ctx, { uploadSecret }) => {
+    verifyUploadSecret(uploadSecret);
+
     const storageFiles = await ctx.db.system.query("_storage").collect();
 
     let totalSize = 0;

--- a/convex/uploadSecret.ts
+++ b/convex/uploadSecret.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared guard for admin-only Convex functions that are called by external
+ * scripts (image optimization, storage cleanup) rather than from the app.
+ *
+ * Mirrors the existing pattern used by the storage/cafe/product mutations:
+ * when `CONVEX_UPLOAD_SECRET` is configured (e.g. production) the secret is
+ * required and must match; when it is unset (local dev) the check is skipped
+ * so scripts can run against a dev deployment without extra setup.
+ */
+export function verifyUploadSecret(uploadSecret?: string): void {
+  const expected = process.env.CONVEX_UPLOAD_SECRET;
+  if (expected && uploadSecret !== expected) {
+    throw new Error("Unauthorized: Invalid upload secret");
+  }
+}

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -247,11 +247,7 @@ export const updateImage = mutation({
     uploadSecret: v.optional(v.string()),
   },
   handler: async (ctx, { userId, storageId, uploadSecret }) => {
-    // Verify upload secret for protected operations
-    const expectedSecret = process.env.CONVEX_UPLOAD_SECRET;
-    if (expectedSecret && uploadSecret !== expectedSecret) {
-      throw new Error("Unauthorized: Invalid upload secret");
-    }
+    verifyUploadSecret(uploadSecret);
 
     await ctx.db.patch(userId, {
       imageStorageId: storageId,
@@ -278,10 +274,15 @@ export const deleteAccount = mutation({
     const affectedProductIds = new Set(userReviews.map((r) => r.productId));
 
     for (const review of userReviews) {
-      // Delete review images from storage
+      // Delete review images from storage. A missing/failed file must not
+      // roll back the whole account deletion, so treat cleanup as best-effort.
       if (review.imageStorageIds) {
         for (const imageId of review.imageStorageIds) {
-          await ctx.storage.delete(imageId);
+          try {
+            await ctx.storage.delete(imageId);
+          } catch (_error) {
+            // Storage cleanup failure is not critical for account deletion
+          }
         }
       }
       // Delete the review
@@ -298,9 +299,13 @@ export const deleteAccount = mutation({
       });
     }
 
-    // Delete user's profile image from storage
+    // Delete user's profile image from storage (best-effort, see above).
     if (user.imageStorageId) {
-      await ctx.storage.delete(user.imageStorageId);
+      try {
+        await ctx.storage.delete(user.imageStorageId);
+      } catch (_error) {
+        // Storage cleanup failure is not critical for account deletion
+      }
     }
 
     // Delete the user record

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -289,9 +289,13 @@ export const deleteAccount = mutation({
     }
 
     // Refresh averageRating/totalReviews for each affected product so the
-    // caches don't keep counting the now-deleted reviews.
+    // caches don't keep counting the now-deleted reviews. Scheduled (rather
+    // than runMutation) so each recompute runs after this deletion commits,
+    // matching how the codebase triggers follow-up work from a mutation.
     for (const productId of affectedProductIds) {
-      await ctx.runMutation(api.reviews.updateProductStats, { productId });
+      await ctx.scheduler.runAfter(0, api.reviews.updateProductStats, {
+        productId,
+      });
     }
 
     // Delete user's profile image from storage

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,7 +1,7 @@
 import { createClerkClient, type UserJSON } from "@clerk/backend";
 import { type Validator, v } from "convex/values";
 import { nanoid } from "nanoid";
-import { internal } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import {
   action,
   internalMutation,
@@ -273,6 +273,10 @@ export const deleteAccount = mutation({
       .withIndex("by_user", (q) => q.eq("userId", user._id))
       .collect();
 
+    // Products whose cached rating stats must be recomputed once this user's
+    // reviews are removed.
+    const affectedProductIds = new Set(userReviews.map((r) => r.productId));
+
     for (const review of userReviews) {
       // Delete review images from storage
       if (review.imageStorageIds) {
@@ -282,6 +286,12 @@ export const deleteAccount = mutation({
       }
       // Delete the review
       await ctx.db.delete(review._id);
+    }
+
+    // Refresh averageRating/totalReviews for each affected product so the
+    // caches don't keep counting the now-deleted reviews.
+    for (const productId of affectedProductIds) {
+      await ctx.runMutation(api.reviews.updateProductStats, { productId });
     }
 
     // Delete user's profile image from storage

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -9,6 +9,7 @@ import {
   type QueryCtx,
   query,
 } from "./_generated/server";
+import { verifyUploadSecret } from "./uploadSecret";
 
 // Move regex to top level for performance
 const HANDLE_REGEX = /^[a-zA-Z0-9_-]+$/;
@@ -225,8 +226,10 @@ export const generateUploadUrl = mutation({
 });
 
 export const getAllWithImages = query({
-  args: {},
-  handler: async (ctx) => {
+  args: { uploadSecret: v.optional(v.string()) },
+  handler: async (ctx, { uploadSecret }) => {
+    verifyUploadSecret(uploadSecret);
+
     const users = await ctx.db
       .query("users")
       .filter((q) => q.neq(q.field("imageStorageId"), undefined))
@@ -263,10 +266,11 @@ export const deleteAccount = mutation({
   handler: async (ctx) => {
     const user = await getCurrentUserOrThrow(ctx);
 
-    // Delete all user's reviews first
+    // Delete all user's reviews first. Reviews store the Convex users._id in
+    // their userId field (not the Clerk externalId), so query by _id.
     const userReviews = await ctx.db
       .query("reviews")
-      .withIndex("by_user", (q) => q.eq("userId", user.externalId))
+      .withIndex("by_user", (q) => q.eq("userId", user._id))
       .collect();
 
     for (const review of userReviews) {

--- a/scripts/cleanupStorage.ts
+++ b/scripts/cleanupStorage.ts
@@ -21,6 +21,10 @@ if (!convexUrl) {
 }
 const client = new ConvexHttpClient(convexUrl);
 
+// Admin read queries are gated by this secret in production. May be undefined
+// in local dev, in which case the server-side check is skipped.
+const UPLOAD_SECRET = process.env.CONVEX_UPLOAD_SECRET;
+
 interface StorageReference {
   field: string;
   recordId: string;
@@ -57,6 +61,7 @@ async function getAllStorageFiles(): Promise<Id<"_storage">[]> {
       } = await client.query(api.storage.getAllStorageFiles, {
         cursor: cursor || undefined,
         limit: 8000,
+        uploadSecret: UPLOAD_SECRET,
       });
 
       allStorageIds.push(...result.files);
@@ -78,7 +83,9 @@ async function getAllStorageFiles(): Promise<Id<"_storage">[]> {
 
 async function getCafeReferences(): Promise<StorageReference[]> {
   const references: StorageReference[] = [];
-  const cafes = await client.query(api.cafes.getAllWithImages);
+  const cafes = await client.query(api.cafes.getAllWithImages, {
+    uploadSecret: UPLOAD_SECRET,
+  });
   for (const cafe of cafes) {
     references.push({
       table: "cafes",
@@ -93,7 +100,9 @@ async function getCafeReferences(): Promise<StorageReference[]> {
 
 async function getProductReferences(): Promise<StorageReference[]> {
   const references: StorageReference[] = [];
-  const products = await client.query(api.products.getAllWithImages);
+  const products = await client.query(api.products.getAllWithImages, {
+    uploadSecret: UPLOAD_SECRET,
+  });
   for (const product of products) {
     references.push({
       table: "products",
@@ -108,7 +117,9 @@ async function getProductReferences(): Promise<StorageReference[]> {
 
 async function getReviewReferences(): Promise<StorageReference[]> {
   const references: StorageReference[] = [];
-  const reviews = await client.query(api.reviews.getAllWithImages);
+  const reviews = await client.query(api.reviews.getAllWithImages, {
+    uploadSecret: UPLOAD_SECRET,
+  });
   for (const review of reviews) {
     // biome-ignore lint/style/noNonNullAssertion: safe by query
     for (const storageId of review.imageStorageIds!) {
@@ -125,7 +136,9 @@ async function getReviewReferences(): Promise<StorageReference[]> {
 
 async function getUserReferences(): Promise<StorageReference[]> {
   const references: StorageReference[] = [];
-  const users = await client.query(api.users.getAllWithImages);
+  const users = await client.query(api.users.getAllWithImages, {
+    uploadSecret: UPLOAD_SECRET,
+  });
   for (const user of users) {
     references.push({
       table: "users",
@@ -182,6 +195,7 @@ async function findDanglingFiles(): Promise<DanglingFile[]> {
   try {
     const metadataResults = await client.query(api.storage.getStorageMetadata, {
       storageIds: danglingStorageIds,
+      uploadSecret: UPLOAD_SECRET,
     });
 
     for (const result of metadataResults) {
@@ -320,7 +334,9 @@ async function deleteDanglingFiles(
 async function showStorageStats() {
   try {
     logger.info("Fetching storage statistics...");
-    const stats = await client.query(api.storage.getStorageStats);
+    const stats = await client.query(api.storage.getStorageStats, {
+      uploadSecret: UPLOAD_SECRET,
+    });
 
     logger.info(`Storage Statistics:
   Total files: ${stats.totalFiles}

--- a/scripts/optimizeImages.ts
+++ b/scripts/optimizeImages.ts
@@ -203,7 +203,9 @@ class ImageOptimizer {
 
     try {
       // Get all products with images
-      const products = await convex.query(api.products.getAllWithImages, {});
+      const products = await convex.query(api.products.getAllWithImages, {
+        uploadSecret: UPLOAD_SECRET,
+      });
 
       logger.info(`Found ${products.length} products with images to process`);
 
@@ -246,7 +248,9 @@ class ImageOptimizer {
 
     try {
       // Get all cafes with images
-      const cafes = await convex.query(api.cafes.getAllWithImages, {});
+      const cafes = await convex.query(api.cafes.getAllWithImages, {
+        uploadSecret: UPLOAD_SECRET,
+      });
 
       logger.info(`Found ${cafes.length} cafes with images to process`);
 
@@ -287,7 +291,9 @@ class ImageOptimizer {
 
     try {
       // Get all users with images
-      const users = await convex.query(api.users.getAllWithImages, {});
+      const users = await convex.query(api.users.getAllWithImages, {
+        uploadSecret: UPLOAD_SECRET,
+      });
 
       logger.info(`Found ${users.length} users with images to process`);
 
@@ -328,7 +334,9 @@ class ImageOptimizer {
 
     try {
       // Get all reviews with images
-      const reviews = await convex.query(api.reviews.getAllWithImages, {});
+      const reviews = await convex.query(api.reviews.getAllWithImages, {
+        uploadSecret: UPLOAD_SECRET,
+      });
 
       logger.info(`Found ${reviews.length} reviews with images to process`);
 

--- a/shared/nutritions.ts
+++ b/shared/nutritions.ts
@@ -1,27 +1,6 @@
-export interface Nutritions {
-  caffeine?: number;
-  caffeineUnit?: string;
-  calories?: number;
-  caloriesUnit?: string;
-  carbohydrates?: number;
-  carbohydratesUnit?: string;
-  cholesterol?: number;
-  cholesterolUnit?: string;
-  fat?: number;
-  fatUnit?: string;
-  natrium?: number;
-  natriumUnit?: string;
-  protein?: number;
-  proteinUnit?: string;
-  saturatedFat?: number;
-  saturatedFatUnit?: string;
-  servingSize?: number;
-  servingSizeUnit?: string;
-  sugar?: number;
-  sugarUnit?: string;
-  transFat?: number;
-  transFatUnit?: string;
-}
+// The Nutritions type is derived from the Convex validator so the field set is
+// defined in exactly one place. See convex/nutritionsValidator.ts.
+export type { Nutritions } from "../convex/nutritionsValidator";
 
 export const dailyStandardNutritions = {
   calories: 2000,

--- a/src/components/reviews/ReviewForm.tsx
+++ b/src/components/reviews/ReviewForm.tsx
@@ -1,5 +1,5 @@
 import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type { Id } from "convex/_generated/dataModel";
 import { useEffect, useState } from "react";
 import { usePostHogEvents } from "~/hooks/usePostHogEvents";
@@ -19,7 +19,6 @@ export function ReviewForm({
   onCancel,
 }: ReviewFormProps) {
   const { data: currentUser } = useQuery(convexQuery(api.users.current, {}));
-  const queryClient = useQueryClient();
   const { trackReviewSubmit } = usePostHogEvents();
   const [rating, setRating] = useState<number>(0);
   const [text, setText] = useState("");
@@ -76,7 +75,8 @@ export function ReviewForm({
   const submitReviewMutation = useMutation({
     mutationFn: useConvexMutation(api.reviews.upsertReview),
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      // Convex queries are live subscriptions (convexQueryClient.connect), so
+      // the review list, stats, and product rating refresh automatically.
       onSuccess?.();
     },
   });
@@ -135,10 +135,9 @@ export function ReviewForm({
         ...newStorageIds,
       ];
 
-      // Submit review
+      // Submit review (the server derives the author from the session)
       await submitReviewMutation.mutateAsync({
         productId,
-        userId: currentUser._id,
         rating,
         text: text.trim() || undefined,
         imageStorageIds:

--- a/src/components/reviews/ReviewSection.tsx
+++ b/src/components/reviews/ReviewSection.tsx
@@ -1,5 +1,5 @@
 import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type { Id } from "convex/_generated/dataModel";
 import { useState } from "react";
 import { showToast } from "~/utils/toast";
@@ -14,7 +14,6 @@ interface ReviewSectionProps {
 
 export function ReviewSection({ productId }: ReviewSectionProps) {
   const { data: currentUser } = useQuery(convexQuery(api.users.current, {}));
-  const queryClient = useQueryClient();
   const [showForm, setShowForm] = useState(false);
   const [_editingReview, setEditingReview] = useState(false);
   const [showSignInModal, setShowSignInModal] = useState(false);
@@ -40,12 +39,10 @@ export function ReviewSection({ productId }: ReviewSectionProps) {
     enabled: !!currentUser?._id,
   });
 
-  // Delete review mutation
+  // Delete review mutation. Convex queries are live subscriptions, so the
+  // review list and stats update automatically after deletion.
   const deleteReviewMutation = useMutation({
     mutationFn: useConvexMutation(api.reviews.deleteReview),
-    onSuccess: () => {
-      queryClient.invalidateQueries();
-    },
   });
 
   const handleWriteReview = () => {
@@ -88,7 +85,6 @@ export function ReviewSection({ productId }: ReviewSectionProps) {
     try {
       await deleteReviewMutation.mutateAsync({
         reviewId: showDeleteConfirm,
-        userId: currentUser._id,
       });
     } catch {
       showToast("후기 삭제에 실패했습니다. 다시 시도해주세요.", "error");


### PR DESCRIPTION
코드베이스 리뷰에서 발견한 보안·데이터 정합성·유지보수성 이슈를 한 번에 수정합니다. 특정 기능과 무관한 독립 변경입니다.

## 🔴 보안 & 데이터 정합성

- **리뷰 mutation이 클라이언트 `userId`를 신뢰하던 문제 차단**
  `upsertReview`/`deleteReview`가 인자로 받은 `userId`를 그대로 쓰는 대신, `getCurrentUserOrThrow`로 서버에서 신원을 확정합니다. 이제 임의 `userId`로 타인 명의 리뷰를 작성·덮어쓰기·삭제할 수 없습니다. `reviews.generateUploadUrl`에도 인증을 추가했습니다.
- **`deleteAccount`가 리뷰를 삭제하지 못하던 버그**
  리뷰는 Convex `users._id`를 저장하는데 `deleteAccount`는 Clerk `externalId`로 조회해, 계정 삭제 시 리뷰·이미지가 고아로 남았습니다. `_id`로 조회하도록 수정하고 스키마 주석도 정정했습니다.
- **전체 테이블 덤프 admin 쿼리 노출 차단**
  `cafes/products/reviews/users.getAllWithImages`와 `storage`의 읽기 쿼리들이 공개 상태라, 익명 호출자에게 **모든 유저의 Clerk id**까지 노출됐습니다. `CONVEX_UPLOAD_SECRET` 게이팅을 추가하고(공용 `verifyUploadSecret` 헬퍼), 스크립트가 시크릿을 전달하도록 했습니다.

## 🟡 유지보수성 & 성능

- **영양정보 정의 단일화** — ~22개 필드가 schema·mutation args·TS 타입·변경감지에 4중 중복돼 있던 것을, 단일 `nutritionsValidator`에서 모두 파생하도록 정리했습니다.
- **검색 스캔 최적화** — `search`/`getSuggestions`가 매 입력마다 전체 products 테이블(비활성 포함)을 collect 하던 것을, 인덱스로 **활성 상품만** 읽도록 변경(부분일치 검색 의미는 유지).
- **리뷰 작성 후 전역 캐시 무효화 제거** — Convex 쿼리는 라이브 구독이라 자동 갱신되므로, 앱 전체를 재요청하던 인자 없는 `invalidateQueries()`를 제거했습니다.

## 검증
- `tsc --noEmit` 통과
- `ultracite` 클린 (pre-commit 훅 포함)
- `vitest run` — 27 passed

## 후속(이 PR 범위 밖)
- 전면 `searchIndex` 도입(한국어 검색 의미가 부분일치→접두사/토큰 일치로 바뀌어 별도 결정 필요)
- `dataUploader`의 `v.array(v.any())` 검증 강화, 크롤러 보일러플레이트 추출, 업로더 전역 TLS 비활성화 정리, `getRecent` 휴리스틱 개선

🤖 Generated with [Claude Code](https://claude.com/claude-code)
