### PR TITLE
fix(oozy-crawler): prevent OOM in 512Mi cron container

### DIFF
--- a/actors/crawler/oozy-crawler.ts
+++ b/actors/crawler/oozy-crawler.ts
@@ -1,5 +1,5 @@
 import { PlaywrightCrawler, type Request } from "crawlee";
-import type { Locator, Page } from "playwright";
+import type { Locator, Page, Route } from "playwright";
 import { logger } from "../../shared/logger";
 import { type Product, waitForLoad, writeProductsToJson } from "./crawlerUtils";
 
@@ -46,10 +46,14 @@ const maxRequestsInTestMode = isTestMode
   ? Number.parseInt(process.env.CRAWLER_MAX_REQUESTS || "10", 10)
   : 50;
 
+// The cron sync (scripts/cronSyncBlockedCafes.sh) runs this crawler inside a
+// 512Mi container. Each oozy page is an imweb image gallery, so keep the
+// default concurrency low to avoid running out of memory. Override with
+// CRAWLER_MAX_CONCURRENCY in less constrained environments.
 const CRAWLER_CONFIG = {
   maxConcurrency: isTestMode
     ? 2
-    : Number.parseInt(process.env.CRAWLER_MAX_CONCURRENCY || "5", 10),
+    : Number.parseInt(process.env.CRAWLER_MAX_CONCURRENCY || "2", 10),
   maxRequestsPerCrawl: isTestMode ? maxRequestsInTestMode : 100,
   maxRequestRetries: 2,
   requestHandlerTimeoutSecs: isTestMode ? 20 : 40,
@@ -70,6 +74,23 @@ const CRAWLER_CONFIG = {
 
 const IMWEB_ID_REGEX = /\/([a-f0-9]{13})\.\w+$/;
 const DATA_ORG_ID_REGEX = /([a-f0-9]{13})\.\w+$/;
+
+// ================================================
+// RESOURCE BLOCKING (memory optimization)
+// ================================================
+
+// The crawler only reads image URLs from DOM attributes (data-src / src), never
+// the decoded image bytes. Aborting image, media, and font downloads keeps the
+// browser's memory footprint low so the crawl fits within the 512Mi cron
+// container. The DOM attributes remain intact even when the request is aborted.
+const BLOCKED_RESOURCE_TYPES = new Set(["image", "media", "font"]);
+
+function blockHeavyResources(route: Route): Promise<void> {
+  if (BLOCKED_RESOURCE_TYPES.has(route.request().resourceType())) {
+    return route.abort();
+  }
+  return route.continue();
+}
 
 // ================================================
 // DATA EXTRACTION FUNCTIONS
@@ -266,6 +287,11 @@ export const createOozyCrawler = () =>
     launchContext: {
       launchOptions: CRAWLER_CONFIG.launchOptions,
     },
+    preNavigationHooks: [
+      async ({ page }) => {
+        await page.route("**/*", blockHeavyResources);
+      },
+    ],
     async requestHandler({ page, request, crawler: crawlerInstance }) {
       if (request.userData?.isMenuPage) {
         await handleMenuPage(page, request, crawlerInstance);


### PR DESCRIPTION
## Problem

The oozy crawl fails with `Out of memory (used over 512Mi)`. Oozy is synced by the Render cron (`scripts/cronSyncBlockedCafes.sh`), which runs inside the 512Mi container defined in `Dockerfile.cron`.

Two things combined to blow past the memory limit:

1. **Concurrency too high.** `oozy-crawler.ts` defaulted to `maxConcurrency: 5` — the highest of the cafes sharing that container (compose uses 3). Every oozy page is an imweb *image gallery*, so up to 5 Chromium pages were each loading a full gallery at once.
2. **Downloading image bytes it never uses.** `extractProductFromItem` / `getImageUrl` only read image **URLs** from DOM attributes (`data-src` / `src`), but Chromium was still downloading and decoding every gallery image into memory.

## Changes

- Lowered the default `maxConcurrency` from **5 → 2** (still overridable via `CRAWLER_MAX_CONCURRENCY`).
- Added a `preNavigationHook` that aborts `image`, `media`, and `font` requests — the biggest memory saver for these gallery pages.

## Verification

- `ultracite fix` clean; no new `tsc` errors.
- Confirmed the request-blocking mechanism with a standalone Playwright test: with the route filter active, image requests are **aborted** yet `data-src`, `src`, and the product-name text remain fully readable from the DOM — so extraction is unaffected.

A live end-to-end run isn't possible in CI/sandbox (oozy blocks cloud IPs — the reason it's on the Render cron — and Crawlee's bundled Chromium build isn't installed in the sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsKvCBP3x6VnqELmAFXca1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsKvCBP3x6VnqELmAFXca1)_