### PR TITLE
Keep Convex functions and analytics out of the initial client bundle

### DIFF
--- a/convex/reviews.ts
+++ b/convex/reviews.ts
@@ -1,33 +1,14 @@
 import { v } from "convex/values";
+import {
+  RATING_TEXTS,
+  RATING_VALUES,
+  type RatingDistribution,
+} from "../shared/ratings";
 import { api } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { mutation, type QueryCtx, query } from "./_generated/server";
 import { verifyUploadSecret } from "./uploadSecret";
 import { getCurrentUserOrThrow } from "./users";
-
-/**
- * Rating scale mapping for Korean labels
- */
-export const RATING_TEXTS = {
-  1: "최악",
-  2: "별로",
-  3: "보통",
-  3.5: "좋음",
-  4: "추천",
-  4.5: "강력 추천",
-  5: "최고",
-} as const;
-
-/**
- * Valid rating values in ascending order
- */
-export const RATING_VALUES = [1, 2, 3, 3.5, 4, 4.5, 5] as const;
-
-export type RatingValue = (typeof RATING_VALUES)[number];
-
-export type RatingDistribution = {
-  [key in RatingValue]: number;
-};
 
 async function resolveImageUrls(
   ctx: QueryCtx,

--- a/shared/ratings.ts
+++ b/shared/ratings.ts
@@ -1,0 +1,23 @@
+/**
+ * Rating scale mapping for Korean labels
+ */
+export const RATING_TEXTS = {
+  1: "최악",
+  2: "별로",
+  3: "보통",
+  3.5: "좋음",
+  4: "추천",
+  4.5: "강력 추천",
+  5: "최고",
+} as const;
+
+/**
+ * Valid rating values in ascending order
+ */
+export const RATING_VALUES = [1, 2, 3, 3.5, 4, 4.5, 5] as const;
+
+export type RatingValue = (typeof RATING_VALUES)[number];
+
+export type RatingDistribution = {
+  [key in RatingValue]: number;
+};

--- a/src/components/RatingSummary.tsx
+++ b/src/components/RatingSummary.tsx
@@ -1,4 +1,4 @@
-import type { RatingDistribution } from "convex/reviews";
+import type { RatingDistribution } from "shared/ratings";
 import { RatingHistogram } from "./reviews/RatingHistogram";
 
 export function RatingSummary({

--- a/src/components/analytics/LazyPostHogProvider.tsx
+++ b/src/components/analytics/LazyPostHogProvider.tsx
@@ -1,0 +1,86 @@
+import type { PostHog } from "posthog-js";
+import { createContext, useContext, useEffect, useState } from "react";
+
+/**
+ * Lazily initialized PostHog context.
+ *
+ * posthog-js (~53KB gzip) is kept out of the initial bundle by importing it
+ * dynamically after the browser goes idle. Until initialization completes,
+ * `usePostHog()` returns null, so consumers must use optional chaining
+ * (`posthog?.capture(...)`) — events fired before init are dropped, which is
+ * acceptable for analytics.
+ */
+const PostHogContext = createContext<PostHog | null>(null);
+
+const IDLE_TIMEOUT_MS = 5000;
+const FALLBACK_DELAY_MS = 2000;
+
+async function initPostHog(): Promise<PostHog | null> {
+  const apiKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
+  if (!apiKey) {
+    return null;
+  }
+
+  const { default: posthog } = await import("posthog-js");
+
+  // Guard against double init (e.g. React strict mode / HMR remounts)
+  if (!posthog.__loaded) {
+    posthog.init(apiKey, {
+      api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+      defaults: "2025-05-24",
+      capture_exceptions: true,
+      debug: import.meta.env.MODE === "development",
+    });
+  }
+
+  return posthog;
+}
+
+export function LazyPostHogProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [client, setClient] = useState<PostHog | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const start = () => {
+      initPostHog()
+        .then((posthog) => {
+          if (!cancelled && posthog) {
+            setClient(posthog);
+          }
+        })
+        .catch(() => {
+          // Analytics failing to load must never break the app
+        });
+    };
+
+    if (typeof window.requestIdleCallback === "function") {
+      const idleId = window.requestIdleCallback(start, {
+        timeout: IDLE_TIMEOUT_MS,
+      });
+      return () => {
+        cancelled = true;
+        window.cancelIdleCallback(idleId);
+      };
+    }
+
+    // Safari: no requestIdleCallback
+    const timerId = window.setTimeout(start, FALLBACK_DELAY_MS);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timerId);
+    };
+  }, []);
+
+  return (
+    <PostHogContext.Provider value={client}>{children}</PostHogContext.Provider>
+  );
+}
+
+export function usePostHog(): PostHog | null {
+  return useContext(PostHogContext);
+}

--- a/src/components/analytics/LazyPostHogProvider.tsx
+++ b/src/components/analytics/LazyPostHogProvider.tsx
@@ -15,25 +15,30 @@ const PostHogContext = createContext<PostHog | null>(null);
 const IDLE_TIMEOUT_MS = 5000;
 const FALLBACK_DELAY_MS = 2000;
 
-async function initPostHog(): Promise<PostHog | null> {
-  const apiKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
-  if (!apiKey) {
-    return null;
-  }
+// Module-level memoization guards against double init (e.g. React strict
+// mode / provider remounts) without relying on posthog-js internals.
+let posthogInitPromise: Promise<PostHog | null> | null = null;
 
-  const { default: posthog } = await import("posthog-js");
+function initPostHog(): Promise<PostHog | null> {
+  posthogInitPromise ??= (async () => {
+    const apiKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
+    if (!apiKey) {
+      return null;
+    }
 
-  // Guard against double init (e.g. React strict mode / HMR remounts)
-  if (!posthog.__loaded) {
+    const { default: posthog } = await import("posthog-js");
+
     posthog.init(apiKey, {
       api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
       defaults: "2025-05-24",
       capture_exceptions: true,
       debug: import.meta.env.MODE === "development",
     });
-  }
 
-  return posthog;
+    return posthog;
+  })();
+
+  return posthogInitPromise;
 }
 
 export function LazyPostHogProvider({

--- a/src/components/profile/ProfileStats.tsx
+++ b/src/components/profile/ProfileStats.tsx
@@ -1,4 +1,4 @@
-import type { RatingDistribution } from "convex/reviews";
+import type { RatingDistribution } from "shared/ratings";
 import { UserRatingHistogram } from "~/components/reviews/UserRatingHistogram";
 
 interface UserStats {

--- a/src/components/reviews/RatingButtonGroup.tsx
+++ b/src/components/reviews/RatingButtonGroup.tsx
@@ -1,4 +1,4 @@
-import { RATING_TEXTS, RATING_VALUES } from "convex/reviews";
+import { RATING_TEXTS, RATING_VALUES } from "shared/ratings";
 
 interface RatingStarsProps {
   onRatingChange?: (rating: number) => void;

--- a/src/components/reviews/RatingHistogram.tsx
+++ b/src/components/reviews/RatingHistogram.tsx
@@ -1,5 +1,4 @@
-import type { RatingDistribution } from "convex/reviews";
-import { RATING_VALUES } from "convex/reviews";
+import { RATING_VALUES, type RatingDistribution } from "shared/ratings";
 
 const WIDE_BAR_RATINGS: readonly number[] = [1, 2, 5];
 

--- a/src/components/reviews/UserRatingHistogram.tsx
+++ b/src/components/reviews/UserRatingHistogram.tsx
@@ -1,5 +1,4 @@
-import type { RatingDistribution } from "../../../convex/reviews";
-import { RATING_TEXTS } from "../../../convex/reviews";
+import { RATING_TEXTS, type RatingDistribution } from "shared/ratings";
 
 interface UserRatingHistogramProps {
   ratingDistribution: RatingDistribution;

--- a/src/hooks/usePostHogEvents.ts
+++ b/src/hooks/usePostHogEvents.ts
@@ -1,5 +1,5 @@
-import { usePostHog } from "posthog-js/react";
 import { useCallback } from "react";
+import { usePostHog } from "~/components/analytics/LazyPostHogProvider";
 
 /**
  * Custom hook for tracking key user events in PostHog

--- a/src/hooks/usePostHogIdentify.ts
+++ b/src/hooks/usePostHogIdentify.ts
@@ -1,7 +1,7 @@
 import { convexQuery } from "@convex-dev/react-query";
 import { useQuery } from "@tanstack/react-query";
-import { usePostHog } from "posthog-js/react";
 import { useEffect, useRef } from "react";
+import { usePostHog } from "~/components/analytics/LazyPostHogProvider";
 import { api } from "../../convex/_generated/api";
 import { usePostHogEvents } from "./usePostHogEvents";
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import type { ConvexReactClient } from "convex/react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
 import type * as React from "react";
 import { lazy, Suspense } from "react";
+import { LazyPostHogProvider } from "~/components/analytics/LazyPostHogProvider";
 
 const TanStackRouterDevtools = import.meta.env.DEV
   ? lazy(() =>
@@ -25,7 +26,6 @@ const TanStackRouterDevtools = import.meta.env.DEV
     )
   : () => null;
 
-import { LazyPostHogProvider } from "~/components/analytics/LazyPostHogProvider";
 import { NewUserRedirect } from "~/components/auth/NewUserRedirect";
 import { DefaultCatchBoundary } from "~/components/DefaultCatchBoundary.js";
 import { Footer } from "~/components/Footer";

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -14,7 +14,6 @@ import { createServerFn, Scripts } from "@tanstack/react-start";
 import { getWebRequest } from "@tanstack/react-start/server";
 import type { ConvexReactClient } from "convex/react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
-import { PostHogProvider } from "posthog-js/react";
 import type * as React from "react";
 import { lazy, Suspense } from "react";
 
@@ -26,6 +25,7 @@ const TanStackRouterDevtools = import.meta.env.DEV
     )
   : () => null;
 
+import { LazyPostHogProvider } from "~/components/analytics/LazyPostHogProvider";
 import { NewUserRedirect } from "~/components/auth/NewUserRedirect";
 import { DefaultCatchBoundary } from "~/components/DefaultCatchBoundary.js";
 import { Footer } from "~/components/Footer";
@@ -134,16 +134,10 @@ export const Route = createRootRouteWithContext<{
 function RootComponent() {
   const context = useRouteContext({ from: Route.id });
   return (
-    <PostHogProvider
-      apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_KEY}
-      options={{
-        api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
-        defaults: "2025-05-24",
-        capture_exceptions: true,
-        debug: import.meta.env.MODE === "development",
-      }}
-    >
-      <ClerkProvider>
+    <LazyPostHogProvider>
+      {/* headless: skip loading clerk-js UI bundles (the app only uses Clerk
+          hooks and control components, never the prebuilt UI) */}
+      <ClerkProvider clerkJSVariant="headless">
         <ConvexProviderWithClerk
           client={context.convexClient}
           useAuth={useAuth}
@@ -154,7 +148,7 @@ function RootComponent() {
           </RootDocument>
         </ConvexProviderWithClerk>
       </ClerkProvider>
-    </PostHogProvider>
+    </LazyPostHogProvider>
   );
 }
 


### PR DESCRIPTION
## What changed

### 1. Convex function file no longer imported in the browser (console error fix)

The deployed site's console repeated `"Convex functions should not be imported in the browser"` dozens of times, because client components imported `RATING_TEXTS` / `RATING_VALUES` / rating types directly from `convex/reviews.ts`. Convex plans to promote this warning to a hard error.

- New `shared/ratings.ts` holds the pure constants/types (`RATING_TEXTS`, `RATING_VALUES`, `RatingValue`, `RatingDistribution`), following the existing `shared/nutritions.ts` pattern.
- `convex/reviews.ts` imports them via `../shared/ratings`.
- All five client components switched to `shared/ratings` — including `UserRatingHistogram.tsx`, which value-imported `RATING_TEXTS` through a relative `../../../convex/reviews` path.
- Verified by grep: no remaining `src/` imports of Convex function files (only `convex/react` and `convex/_generated` remain).

### 2. Clerk + PostHog no longer fully loaded for anonymous first visits

**PostHog** — `posthog-js/react` statically imports the posthog-js core, so option tweaks can't remove it from the bundle. Replaced with `src/components/analytics/LazyPostHogProvider.tsx`:
- Dynamically `import("posthog-js")` after `requestIdleCallback` (2s `setTimeout` fallback for Safari), with double-init guard.
- Its `usePostHog()` returns `null` until init; `usePostHogEvents` / `usePostHogIdentify` already use `posthog?.capture` optional chaining, so no call-site changes.
- Build result: `vendor-posthog` (~55KB gzip) is referenced only by one dynamic import — it's out of the initial graph.

**Clerk** — the app uses only headless-compatible pieces (`useAuth`, `useUser`, `useSignIn`, `SignOutButton`, `AuthenticateWithRedirectCallback`; no prebuilt UI like `<UserButton>`), so `ClerkProvider` now sets `clerkJSVariant="headless"`. The browser loads `clerk.headless.browser.js` instead of `clerk.browser.js` and never downloads the `ui-common` bundle (~119KB observed on prod). The React SDK chunk (`vendor-clerk`, ~29KB gzip) stays in the root graph since `ConvexProviderWithClerk` needs it — intentionally left alone to avoid risky restructuring.

## Verification

- `npx ultracite check`, `tsc --noEmit`, and `pnpm build` all pass.
- Manual run against the dev server:
  - No "Convex functions should not be imported in the browser" warning; zero console errors.
  - Sign-in modal renders with all social buttons enabled (`useSignIn().isLoaded === true` under headless clerk-js), and clicking Google redirects to the real Google OAuth page.
  - Direct `/oauth-callback` visits are handled without errors.
  - Network timeline confirms `clerk.headless.browser.js` only, and posthog-js loading ~1.2s after idle.

## Reviewer notes

- Analytics events fired before the idle init are dropped (client is `null`); this is the intended trade-off.
- The one-time `/v1/environment` + `/v1/client` Clerk API calls still happen — they're required by clerk-js regardless of variant.
- The `vendor-clerk ... "import.meta" is not available (es2019)` build warning is pre-existing (Clerk SDK code in the nitro server bundle), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)