### PR TITLE
UI/UX polish: empty-state ratings, search onboarding, slimmer hero, nutrition bar colors

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "janjum-dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -46,7 +46,7 @@ export function Footer() {
 
           {/* Copyright */}
           <div className="text-center text-base-content/60 text-xs">
-            <p>&copy; 2025 잔점. All rights reserved.</p>
+            <p>&copy; {new Date().getFullYear()} 잔점. All rights reserved.</p>
           </div>
         </div>
       </div>

--- a/src/components/NutritionLevels.tsx
+++ b/src/components/NutritionLevels.tsx
@@ -5,6 +5,15 @@ export interface NutritionLevelsProps {
   nutritions?: Nutritions | null;
 }
 
+// Literal class names so Tailwind's source scan generates them
+// (a `progress-${color}` template would be dropped from the bundle)
+const progressColorClasses: Record<string, string> = {
+  success: "progress-success",
+  warning: "progress-warning",
+  error: "progress-error",
+  neutral: "progress-neutral",
+};
+
 // Convert nutrition level to progress percentage
 function levelTextToProgressValue(levelText: string): number {
   switch (levelText) {
@@ -60,7 +69,7 @@ export function NutritionLevels({ nutritions }: NutritionLevelsProps) {
         }
 
         const progressValue = levelTextToProgressValue(level.text);
-        const progressColorClass = `progress-${level.color}`;
+        const progressColorClass = progressColorClasses[level.color] ?? "";
 
         return (
           <div className="flex items-center gap-2 text-sm" key={key}>

--- a/src/components/RatingSummary.tsx
+++ b/src/components/RatingSummary.tsx
@@ -14,11 +14,21 @@ export function RatingSummary({
 }) {
   const noReview = reviewStats.totalReviews === 0;
 
+  if (noReview) {
+    return (
+      <div className={`flex h-6 items-center ${className ?? ""}`}>
+        <span className="text-base-content/50 text-sm">
+          첫 리뷰를 남겨보세요
+        </span>
+      </div>
+    );
+  }
+
   return (
-    <div className={`flex items-center gap-3 ${className}`}>
+    <div className={`flex items-center gap-3 ${className ?? ""}`}>
       <RatingHistogram ratingDistribution={reviewStats.ratingDistribution} />
       <span className="font-medium text-primary">
-        {noReview ? "?" : reviewStats.averageRating.toFixed(1)}
+        {reviewStats.averageRating.toFixed(1)}
       </span>
       <span className="text-base-content/60 text-sm">
         ({reviewStats.totalReviews})

--- a/src/components/reviews/ReviewSection.tsx
+++ b/src/components/reviews/ReviewSection.tsx
@@ -94,6 +94,7 @@ export function ReviewSection({ productId }: ReviewSectionProps) {
   };
 
   const hasUserReview = !!userReview;
+  const hasReviews = !!reviews && reviews.length > 0;
 
   return (
     <div className="space-y-6">
@@ -105,7 +106,7 @@ export function ReviewSection({ productId }: ReviewSectionProps) {
 
         {!showForm && (
           <div className="flex gap-2">
-            {!currentUser && (
+            {!currentUser && hasReviews && (
               <button
                 className="btn btn-primary btn-sm"
                 onClick={() => setShowSignInModal(true)}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -107,7 +107,7 @@ export const Route = createRootRouteWithContext<{
         sizes: "16x16",
         href: "/favicon-16x16.png",
       },
-      { rel: "manifest", href: "/site.webmanifest", color: "#fffff" },
+      { rel: "manifest", href: "/site.webmanifest" },
       { rel: "icon", href: "/favicon.ico" },
     ],
   }),

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,9 @@
 import { convexQuery } from "@convex-dev/react-query";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { BrandCafeListSection } from "~/components/BrandCafeListSection";
+import { SearchIcon } from "~/components/icons/SearchIcon";
 import {
   NewProductsSection,
   recentProductsQueryOptions,
@@ -32,16 +34,40 @@ export const Route = createFileRoute("/")({
 
 function Home() {
   const { data: cafes } = useSuspenseQuery(convexQuery(api.cafes.list, {}));
+  const navigate = useNavigate();
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const handleSearchSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    navigate({
+      to: "/search",
+      search: { searchTerm: searchTerm.trim() },
+    });
+  };
 
   return (
     <div className="min-h-screen bg-base-200">
       {/* Hero Section */}
-      <div className="hero bg-gradient-to-b from-primary to-secondary py-8 text-primary-content">
-        <div className="hero-content text-center">
-          <div className="max-w-md">
-            <h1 className="mb-5 font-bold font-sunflower text-5xl">잔점</h1>
-            <p className="mb-5 text-lg">카페 음료의 모든 것을 한곳에서!</p>
+      <div className="hero bg-gradient-to-b from-primary to-secondary py-6 text-primary-content">
+        <div className="hero-content w-full max-w-md flex-col gap-4 text-center">
+          <div>
+            <h1 className="font-bold font-sunflower text-4xl">잔점</h1>
+            <p className="mt-2">카페 음료의 모든 것을 한곳에서!</p>
           </div>
+          <form className="join w-full" onSubmit={handleSearchSubmit}>
+            <input
+              aria-label="음료명 검색"
+              className="input join-item flex-1 text-base-content"
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder="음료명을 검색해보세요"
+              type="search"
+              value={searchTerm}
+            />
+            <button className="btn btn-neutral join-item" type="submit">
+              <SearchIcon size="sm" />
+              검색
+            </button>
+          </form>
         </div>
       </div>
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -39,9 +39,13 @@ function Home() {
 
   const handleSearchSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const trimmedSearchTerm = searchTerm.trim();
+    if (!trimmedSearchTerm) {
+      return;
+    }
     navigate({
       to: "/search",
-      search: { searchTerm: searchTerm.trim() },
+      search: { searchTerm: trimmedSearchTerm },
     });
   };
 

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -112,24 +112,35 @@ function SearchPage() {
 
       {/* Search Results */}
       <div className="container mx-auto px-4 py-8">
-        <div className="mb-6 flex items-center justify-between">
-          <h2 className="font-semibold text-xl">
-            검색 결과 ({searchResults?.length || 0}개)
-          </h2>
-        </div>
+        {searchTerm?.trim() ? (
+          <>
+            <div className="mb-6 flex items-center justify-between">
+              <h2 className="font-semibold text-xl">
+                검색 결과 ({searchResults?.length || 0}개)
+              </h2>
+            </div>
 
-        {searchResults && searchResults.length > 0 ? (
-          <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
-            {searchResults.map((product) => (
-              <ProductCard key={product._id} product={product} />
-            ))}
-          </div>
+            {searchResults && searchResults.length > 0 ? (
+              <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+                {searchResults.map((product) => (
+                  <ProductCard key={product._id} product={product} />
+                ))}
+              </div>
+            ) : (
+              <div className="py-16 text-center">
+                <h3 className="mb-2 font-semibold text-lg">
+                  검색 결과가 없습니다
+                </h3>
+                <p className="mb-4 text-base-content/60">
+                  다른 검색어를 시도해보세요.
+                </p>
+              </div>
+            )}
+          </>
         ) : (
-          <div className="py-16 text-center">
-            <h3 className="mb-2 font-semibold text-lg">검색 결과가 없습니다</h3>
-            <p className="mb-4 text-base-content/60">
-              다른 검색어를 시도해보세요.
-            </p>
+          <div className="py-16 text-center text-base-content/60">
+            <SearchIcon className="mx-auto mb-4 h-10 w-10" />
+            <p>음료명으로 검색해보세요</p>
           </div>
         )}
       </div>


### PR DESCRIPTION
## What changed

Six independent UI/UX fixes, one commit each:

1. **Rating empty state** (`src/components/RatingSummary.tsx`) — products with zero reviews showed an empty histogram bar, a `?`, and `(0)`, which looked like a rendering bug. They now show a quiet "첫 리뷰를 남겨보세요" line at the same height, so card grids stay aligned.
2. **Search onboarding** (`src/routes/search.tsx`) — landing on `/search` with no query showed "검색 결과 (0개)" and the no-results empty state. It now shows a search icon with a prompt until a term is actually submitted; "검색 결과가 없습니다" only appears for a real zero-result search.
3. **Slimmer hero with search** (`src/routes/index.tsx`) — the hero took over half the mobile viewport with just a title and slogan. Reduced padding/title size and added a search form that navigates to `/search?searchTerm=…`; the hero is now ~27% of a 375px viewport.
4. **Duplicate sign-in CTA** (`src/components/reviews/ReviewSection.tsx`) — signed-out users saw two "소셜 계정으로 로그인" buttons on review-less products. The header button now only renders when reviews exist; the empty-state card owns the CTA otherwise.
5. **Nutrition bar colors** (`src/components/NutritionLevels.tsx`) — the semantic color logic already existed, but the class was built as `progress-${level.color}`, so Tailwind 4's source scan never generated `progress-success/warning/error` and every bar rendered in the default color. Colors now map to literal class names; text labels are kept for accessibility.
6. **Small fixes** — footer copyright year is now dynamic (`Footer.tsx`), and the invalid `color: "#fffff"` attribute (malformed 5-digit hex, not valid on `rel=manifest`) was removed from the manifest link in `__root.tsx`.

Also adds `.claude/launch.json` (dev-server preview config used for verification).

## Why

Follow-ups from a desktop/mobile UX review of the live site: the `?` rating and empty search results read as bugs, the hero pushed new products below the fold on mobile, and the nutrition bars were unscannable.

## Reviewer notes

- Verified with `pnpm run build` (vite build + `tsc --noEmit`) and manually in a 375px viewport: hero search → results flow, `/search` initial state, product detail nutrition colors (많음=red, 카페인 보통=neutral), single sign-in CTA, © 2026 footer.
- Two parallel sessions may touch `RatingSummary.tsx` and `__root.tsx`; changes here were kept minimal (render-only in RatingSummary, one line in `__root.tsx`) to reduce conflict surface.
- `theme-color` meta was intentionally not added — unclear if that was the original intent of the removed `color` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)