### PR TITLE
Fix /new page performance: batch review stats and paginate

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,11 +17,13 @@ import type * as cafes from "../cafes.js";
 import type * as dataUploader from "../dataUploader.js";
 import type * as http from "../http.js";
 import type * as imageDownloader from "../imageDownloader.js";
+import type * as nutritionsValidator from "../nutritionsValidator.js";
 import type * as products from "../products.js";
 import type * as reviews from "../reviews.js";
 import type * as shortId from "../shortId.js";
 import type * as stats from "../stats.js";
 import type * as storage from "../storage.js";
+import type * as uploadSecret from "../uploadSecret.js";
 import type * as users from "../users.js";
 
 /**
@@ -37,11 +39,13 @@ declare const fullApi: ApiFromModules<{
   dataUploader: typeof dataUploader;
   http: typeof http;
   imageDownloader: typeof imageDownloader;
+  nutritionsValidator: typeof nutritionsValidator;
   products: typeof products;
   reviews: typeof reviews;
   shortId: typeof shortId;
   stats: typeof stats;
   storage: typeof storage;
+  uploadSecret: typeof uploadSecret;
   users: typeof users;
 }>;
 export declare const api: FilterApi<

--- a/convex/products.ts
+++ b/convex/products.ts
@@ -339,8 +339,9 @@ export const upsertProduct = mutation({
 export const getRecent = query({
   args: {
     limit: v.optional(v.number()),
+    offset: v.optional(v.number()),
   },
-  handler: async (ctx, { limit }) => {
+  handler: async (ctx, { limit, offset }) => {
     const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
     const oneDayMs = 24 * 60 * 60 * 1000;
 
@@ -379,7 +380,10 @@ export const getRecent = query({
     // Sort by addedAt descending (newest first)
     filtered.sort((a, b) => b.addedAt - a.addedAt);
 
-    const limited = limit ? filtered.slice(0, limit) : filtered;
+    const start = offset ?? 0;
+    const limited = limit
+      ? filtered.slice(start, start + limit)
+      : filtered.slice(start);
 
     const productsWithCafes = await Promise.all(
       limited.map(async (product) => {

--- a/convex/reviews.ts
+++ b/convex/reviews.ts
@@ -123,6 +123,31 @@ export const getProductStats = query({
 });
 
 /**
+ * Get review statistics for many products in a single call.
+ * Used by product list views so each card doesn't need its own query.
+ */
+export const getProductStatsBatch = query({
+  args: { productIds: v.array(v.id("products")) },
+  handler: async (ctx, { productIds }) => {
+    const entries = await Promise.all(
+      productIds.map(async (productId) => {
+        const reviews = await ctx.db
+          .query("reviews")
+          .withIndex("by_product", (q) => q.eq("productId", productId))
+          .filter((q) => q.neq(q.field("isVisible"), false))
+          .collect();
+        return [productId, computeRatingStats(reviews)] as const;
+      })
+    );
+
+    return Object.fromEntries(entries) as Record<
+      Id<"products">,
+      ReturnType<typeof computeRatingStats>
+    >;
+  },
+});
+
+/**
  * Check if user has already reviewed a product
  */
 export const getUserReview = query({

--- a/src/components/NewProductsSection.tsx
+++ b/src/components/NewProductsSection.tsx
@@ -2,6 +2,7 @@ import { convexQuery } from "@convex-dev/react-query";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { api } from "../../convex/_generated/api";
+import { useProductReviewStats } from "../hooks/useProductReviewStats";
 import { ProductCard } from "./ProductCard";
 
 const STALE_TIME = 60 * 60 * 1000; // 1 hour
@@ -11,13 +12,21 @@ export const recentProductsQueryOptions = {
   staleTime: STALE_TIME,
 };
 
-export const recentProductsAllQueryOptions = {
-  ...convexQuery(api.products.getRecent, {}),
+export const NEW_PRODUCTS_PAGE_SIZE = 40;
+
+export const recentProductsPageQueryOptions = (offset: number) => ({
+  ...convexQuery(api.products.getRecent, {
+    limit: NEW_PRODUCTS_PAGE_SIZE,
+    offset,
+  }),
   staleTime: STALE_TIME,
-};
+});
 
 export function NewProductsSection() {
   const { data } = useSuspenseQuery(recentProductsQueryOptions);
+  const reviewStats = useProductReviewStats(
+    data.products.map((product) => product._id)
+  );
 
   if (data.products.length === 0) {
     return null;
@@ -38,7 +47,11 @@ export function NewProductsSection() {
       </div>
       <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
         {data.products.map((product) => (
-          <ProductCard key={product._id} product={product} />
+          <ProductCard
+            key={product._id}
+            product={product}
+            reviewStats={reviewStats?.[product._id]}
+          />
         ))}
       </div>
     </div>

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,40 +1,39 @@
-import { convexQuery } from "@convex-dev/react-query";
-import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import type { ComponentProps } from "react";
 
-import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 import { RatingSummary } from "../components/RatingSummary";
+
+type ReviewStats = ComponentProps<typeof RatingSummary>["reviewStats"];
+
+const defaultReviewStats: ReviewStats = {
+  averageRating: 0,
+  totalReviews: 0,
+  ratingDistribution: {
+    1: 0,
+    2: 0,
+    3: 0,
+    4: 0,
+    5: 0,
+    3.5: 0,
+    4.5: 0,
+  },
+};
 
 export function ProductCard({
   product,
   priority = false,
+  reviewStats,
 }: {
   product: Doc<"products"> & {
     cafeName?: string;
     imageUrl?: string;
   };
   priority?: boolean;
+  // Provided by the list container via a single batched stats query
+  // (useProductReviewStats) instead of one query per card.
+  reviewStats?: ReviewStats;
 }) {
-  const { data: reviewStats } = useQuery({
-    ...convexQuery(api.reviews.getProductStats, { productId: product._id }),
-    enabled: !!product._id,
-  });
-
-  const defaultReviewStats = {
-    averageRating: 0,
-    totalReviews: 0,
-    ratingDistribution: {
-      1: 0,
-      2: 0,
-      3: 0,
-      4: 0,
-      5: 0,
-      3.5: 0,
-      4.5: 0,
-    },
-  };
-
   const { isActive } = product;
 
   return (
@@ -68,7 +67,7 @@ export function ProductCard({
             {product.name}
           </h3>
         </div>
-        <RatingSummary reviewStats={reviewStats || defaultReviewStats} />
+        <RatingSummary reviewStats={reviewStats ?? defaultReviewStats} />
         <div className="flex items-center justify-between">
           <div className="space-y-1">
             {product.price && (

--- a/src/hooks/useProductReviewStats.ts
+++ b/src/hooks/useProductReviewStats.ts
@@ -1,0 +1,18 @@
+import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+
+/**
+ * Fetch review stats for a whole product list with a single Convex query,
+ * instead of one query (and one reactive subscription) per ProductCard.
+ * Returns a record keyed by productId, or undefined while loading.
+ */
+export function useProductReviewStats(productIds: Id<"products">[]) {
+  const { data } = useQuery({
+    ...convexQuery(api.reviews.getProductStatsBatch, { productIds }),
+    enabled: productIds.length > 0,
+  });
+
+  return data;
+}

--- a/src/routes/cafe.$slug.tsx
+++ b/src/routes/cafe.$slug.tsx
@@ -11,6 +11,7 @@ import {
   OrderSelector,
 } from "~/components/cafe/OrderSelector";
 import { ProductSearchInput } from "~/components/cafe/ProductSearchInput";
+import { useProductReviewStats } from "~/hooks/useProductReviewStats";
 import { api } from "../../convex/_generated/api";
 import { ProductCard } from "../components/ProductCard";
 import { getOrderedCategories } from "../utils/categories";
@@ -62,6 +63,10 @@ function CafePage() {
   });
 
   const [searchQuery, setSearchQuery] = useState("");
+
+  const reviewStats = useProductReviewStats(
+    products?.map((product) => product._id) ?? []
+  );
 
   const availableCategories = Array.from(
     new Set(products?.map((p) => p.category).filter(Boolean) || [])
@@ -180,6 +185,7 @@ function CafePage() {
                   key={product._id}
                   priority={index < 8}
                   product={product}
+                  reviewStats={reviewStats?.[product._id]}
                 />
               ))}
         </div>

--- a/src/routes/new.tsx
+++ b/src/routes/new.tsx
@@ -1,15 +1,21 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQueries } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { recentProductsAllQueryOptions } from "~/components/NewProductsSection";
+import { useState } from "react";
+import {
+  NEW_PRODUCTS_PAGE_SIZE,
+  recentProductsPageQueryOptions,
+} from "~/components/NewProductsSection";
 import { ProductCard } from "~/components/ProductCard";
+import { useProductReviewStats } from "~/hooks/useProductReviewStats";
 import type { Doc } from "../../convex/_generated/dataModel";
 import { seo } from "../utils/seo";
 
 export const Route = createFileRoute("/new")({
   component: NewProductsPage,
   loader: async (opts) => {
+    // SSR only the first page; further pages load on demand via "더 보기".
     await opts.context.queryClient.ensureQueryData(
-      recentProductsAllQueryOptions
+      recentProductsPageQueryOptions(0)
     );
   },
   head: () => ({
@@ -73,27 +79,50 @@ function groupByCafe(
 }
 
 function NewProductsPage() {
-  const { data } = useSuspenseQuery(recentProductsAllQueryOptions);
-  const cafeGroups = groupByCafe(data.products);
+  const [pageCount, setPageCount] = useState(1);
+
+  const pageQueries = useQueries({
+    queries: Array.from({ length: pageCount }, (_, pageIndex) =>
+      recentProductsPageQueryOptions(pageIndex * NEW_PRODUCTS_PAGE_SIZE)
+    ),
+  });
+
+  const products = pageQueries.flatMap((page) => page.data?.products ?? []);
+  const totalCount = pageQueries.at(0)?.data?.totalCount ?? 0;
+  const hasMore = products.length < totalCount;
+  const isLoadingMore = pageQueries.some((page) => page.isPending);
+
+  const reviewStats = useProductReviewStats(
+    products.map((product) => product._id)
+  );
+  const cafeGroups = groupByCafe(products);
 
   return (
     <div className="min-h-screen bg-base-200">
       <div className="container mx-auto px-4 py-8">
-        <h1 className="mb-8 font-bold text-3xl">신상품</h1>
+        <h1 className="mb-8 font-bold text-3xl">
+          신상품{" "}
+          {totalCount > 0 && (
+            <span className="text-base-content/50 text-xl">{totalCount}</span>
+          )}
+        </h1>
 
-        {cafeGroups.length === 0 && (
+        {cafeGroups.length === 0 && !isLoadingMore && (
           <p className="text-center text-base-content/60">
             최근 30일 이내 신상품이 없습니다.
           </p>
         )}
 
-        {cafeGroups.map(({ cafeName, products }) => (
+        {cafeGroups.map(({ cafeName, products: cafeProducts }) => (
           <div className="mb-10" key={cafeName}>
             <h2 className="mb-4 font-bold text-xl">{cafeName}</h2>
             <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-              {products.map((product) => (
+              {cafeProducts.map((product) => (
                 <div key={product._id}>
-                  <ProductCard product={product} />
+                  <ProductCard
+                    product={product}
+                    reviewStats={reviewStats?.[product._id]}
+                  />
                   <p className="mt-1 text-base-content/50 text-xs">
                     {formatRelativeDate(product.addedAt)}
                   </p>
@@ -102,6 +131,21 @@ function NewProductsPage() {
             </div>
           </div>
         ))}
+
+        {hasMore && (
+          <div className="flex justify-center">
+            <button
+              className="btn btn-outline btn-wide"
+              disabled={isLoadingMore}
+              onClick={() => setPageCount((count) => count + 1)}
+              type="button"
+            >
+              {isLoadingMore
+                ? "불러오는 중..."
+                : `더 보기 (${totalCount - products.length}개 남음)`}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -3,6 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 import { usePostHogEvents } from "~/hooks/usePostHogEvents";
+import { useProductReviewStats } from "~/hooks/useProductReviewStats";
 import { api } from "../../convex/_generated/api";
 import { SearchIcon } from "../components/icons/SearchIcon";
 import { ProductCard } from "../components/ProductCard";
@@ -53,6 +54,10 @@ function SearchPage() {
 
   const { data: searchResults } = useSuspenseQuery(
     convexQuery(api.products.search, searchParams)
+  );
+
+  const reviewStats = useProductReviewStats(
+    searchResults?.map((product) => product._id) ?? []
   );
 
   // Handle form submission
@@ -121,7 +126,11 @@ function SearchPage() {
         {searchResults && searchResults.length > 0 ? (
           <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
             {searchResults.map((product) => (
-              <ProductCard key={product._id} product={product} />
+              <ProductCard
+                key={product._id}
+                product={product}
+                reviewStats={reviewStats?.[product._id]}
+              />
             ))}
           </div>
         ) : (


### PR DESCRIPTION
## 문제

/new(신상품 전체) 페이지 진입 시:

- 상품 카드 ~300개가 한 번에 렌더링되어 문서 높이가 약 51,000px에 달함
- `ProductCard`가 카드마다 `reviews.getProductStats`를 개별 호출해 **상품 수만큼 Convex 구독이 생성**되는 N+1 문제

## 변경 사항

### 리뷰 통계 배치화 (N+1 제거)

- `reviews.getProductStatsBatch` 추가: productId 배열을 받아 `{ productId: stats }` 레코드를 단일 쿼리로 반환
- `ProductCard`의 내부 `useQuery` 제거, `reviewStats`를 optional prop으로 수신 (없으면 기존과 동일한 0점 기본값)
- 공용 훅 `useProductReviewStats` 추가, ProductCard 사용처 4곳(홈 신상품 섹션, /new, 검색, 카페 페이지) 모두 일관 적용
- 구독 수가 상품 수와 무관해짐: **목록 쿼리 1개 + 배치 stats 쿼리 1개**

### /new 페이지네이션

- `products.getRecent`에 optional `offset` 인자 추가 (필터·정렬 후 슬라이스, `totalCount`는 전체 기준 유지)
- /new는 40개 단위로 로드: 첫 페이지는 기존대로 loader `ensureQueryData`로 SSR, 이후 페이지는 `useQueries`로 이어 붙이고 "더 보기 (N개 남음)" 버튼으로 로드
- 홈 신상품 섹션(limit 4)은 동작 불변

### 참고

- 스키마에 이미 `averageRating`/`totalReviews`가 비정규화되어 있으나, 카드의 `RatingSummary`가 히스토그램용 `ratingDistribution`을 요구해 배치 쿼리 방식을 택함. 추후 distribution까지 비정규화하면 배치 쿼리도 제거 가능

## 검증

- `vite build && tsc --noEmit` 통과, `ultracite check` 클린
- dev 배포에 푸시 후 로컬에서 확인:
  - 카페 페이지(스타벅스 182개): 카드 정상 렌더링, 배치 쿼리에서 온 실제 평점 `4.0 (1)` 표시
  - 검색(라떼 100개), 홈, /new 정상 렌더링
  - dev DB에 최근 30일 신상품이 없어 /new "더 보기"는 실데이터로 확인하지 못함. 대신 `npx convex run`으로 `getRecent`의 offset 슬라이싱과 `getProductStatsBatch` 반환값을 직접 검증
- 프로덕션 반영 시 새 Convex 함수 배포가 프론트 배포와 함께 이뤄져야 함 (기존 `getProductStats`는 상세 페이지에서 계속 사용하므로 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)