### PR TITLE
Fix re-imported menus flooding the new-products list (Compose)

### DIFF
--- a/convex/productMatching.test.ts
+++ b/convex/productMatching.test.ts
@@ -32,4 +32,14 @@ describe("normalizeProductName", () => {
     // No latin marker + separator, so the whole name is the base key.
     expect(normalizeProductName("한라봉주스")).toBe("한라봉주스");
   });
+
+  it("does not treat a bare single letter + space as a temperature marker", () => {
+    // "H 하우스" is neither the "HOT "/"ICE " word form nor the "H-"/"I-" form,
+    // so it must not fold to a temperature key (which could collide with an
+    // unrelated product).
+    expect(normalizeProductName("H 하우스블렌드")).toBe("h하우스블렌드");
+    expect(normalizeProductName("H 하우스블렌드")).not.toBe(
+      normalizeProductName("HOT 하우스블렌드")
+    );
+  });
 });

--- a/convex/productMatching.test.ts
+++ b/convex/productMatching.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { normalizeProductName } from "./productMatching";
+
+describe("normalizeProductName", () => {
+  it("collapses old 'HOT '/'ICE ' and new 'H-'/'I-' markers to the same key", () => {
+    expect(normalizeProductName("HOT 아메리카노")).toBe(
+      normalizeProductName("H-아메리카노")
+    );
+    expect(normalizeProductName("ICE 헤이즐넛 라떼")).toBe(
+      normalizeProductName("I-헤이즐넛라떼")
+    );
+  });
+
+  it("keeps hot and iced variants distinct", () => {
+    expect(normalizeProductName("H-아메리카노")).not.toBe(
+      normalizeProductName("I-아메리카노")
+    );
+  });
+
+  it("normalizes whitespace and hyphens in the base name", () => {
+    expect(normalizeProductName("디카페인 콜드브루")).toBe(
+      normalizeProductName("디카페인콜드브루")
+    );
+  });
+
+  it("leaves names without a temperature marker untouched apart from spacing", () => {
+    expect(normalizeProductName("에스프레소")).toBe("에스프레소");
+    expect(normalizeProductName(" 에스프레소 ")).toBe("에스프레소");
+  });
+
+  it("does not treat a hangul name as a temperature marker", () => {
+    // No latin marker + separator, so the whole name is the base key.
+    expect(normalizeProductName("한라봉주스")).toBe("한라봉주스");
+  });
+});

--- a/convex/productMatching.ts
+++ b/convex/productMatching.ts
@@ -9,7 +9,11 @@
  * but "H-"/"I-" on the rebuilt one) and whitespace/hyphens. The temperature is
  * kept in the key so a hot and an iced variant never collapse together.
  */
-const TEMPERATURE_PREFIX = /^(hot|ice|h|i)[\s-]+/;
+// Matches only the two real schemes: the old "HOT "/"ICE " word form (word +
+// space/hyphen) and the new "H-"/"I-" single-letter form (letter + hyphen). A
+// bare single letter + space (e.g. "H 하우스") is intentionally NOT treated as a
+// temperature marker, so unrelated names aren't folded together.
+const TEMPERATURE_PREFIX = /^(hot|ice)[\s-]+|^(h|i)-+/;
 const SEPARATORS = /[\s-]/g;
 
 export function normalizeProductName(name: string): string {
@@ -19,7 +23,7 @@ export function normalizeProductName(name: string): string {
   let temperature = "";
   let rest = lowered;
   if (prefixMatch) {
-    const token = prefixMatch[1];
+    const token = prefixMatch[1] ?? prefixMatch[2];
     temperature = token === "h" || token === "hot" ? "hot" : "ice";
     rest = lowered.slice(prefixMatch[0].length);
   }

--- a/convex/productMatching.ts
+++ b/convex/productMatching.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure helpers for matching products across crawls when a cafe's website
+ * changes its `externalId` scheme (e.g. a CMS rebuild). When the external id
+ * is no longer stable, the same menu item can only be recognised by its name,
+ * so we normalise names into a comparable key.
+ *
+ * The key folds away the two things that vary between id schemes for the same
+ * drink: the hot/iced marker (written as "HOT "/"ICE " on the old Compose site
+ * but "H-"/"I-" on the rebuilt one) and whitespace/hyphens. The temperature is
+ * kept in the key so a hot and an iced variant never collapse together.
+ */
+const TEMPERATURE_PREFIX = /^(hot|ice|h|i)[\s-]+/;
+const SEPARATORS = /[\s-]/g;
+
+export function normalizeProductName(name: string): string {
+  const lowered = name.trim().toLowerCase();
+  const prefixMatch = lowered.match(TEMPERATURE_PREFIX);
+
+  let temperature = "";
+  let rest = lowered;
+  if (prefixMatch) {
+    const token = prefixMatch[1];
+    temperature = token === "h" || token === "hot" ? "hot" : "ice";
+    rest = lowered.slice(prefixMatch[0].length);
+  }
+
+  const base = rest.replace(SEPARATORS, "");
+  return temperature ? `${temperature}:${base}` : base;
+}

--- a/convex/products.ts
+++ b/convex/products.ts
@@ -9,6 +9,7 @@ import {
   query,
 } from "./_generated/server";
 import { nutritionsValidator } from "./nutritionsValidator";
+import { normalizeProductName } from "./productMatching";
 import { verifyUploadSecret } from "./uploadSecret";
 
 // Field names derived from the validator so changes stay in one place.
@@ -276,6 +277,34 @@ async function handleExistingProduct(
   return { action: "unchanged", id: existing._id };
 }
 
+/**
+ * When a cafe changes its `externalId` scheme (e.g. a CMS rebuild), a returning
+ * menu item is no longer found by `externalId` and would be recreated as brand
+ * new — resetting its `addedAt` and orphaning its reviews/shortId. Before
+ * creating, look for a previously soft-removed product in the same cafe whose
+ * name matches. Only reuse when the match is unambiguous (exactly one), so a
+ * genuinely new drink is never merged into an unrelated old record.
+ */
+async function findRevivableProduct(
+  ctx: MutationCtx,
+  cafeId: Id<"cafes">,
+  name: string
+): Promise<ExistingProduct | null> {
+  const removed = await ctx.db
+    .query("products")
+    .withIndex("by_cafe_active", (q) =>
+      q.eq("cafeId", cafeId).eq("isActive", false)
+    )
+    .collect();
+
+  const targetKey = normalizeProductName(name);
+  const matches = removed.filter(
+    (product) => normalizeProductName(product.name) === targetKey
+  );
+
+  return matches.length === 1 ? matches[0] : null;
+}
+
 async function createNewProduct(
   ctx: MutationCtx,
   args: UpsertProductArgs,
@@ -330,6 +359,14 @@ export const upsertProduct = mutation({
 
     if (existing) {
       return await handleExistingProduct(ctx, args, existing, now);
+    }
+
+    // No match by externalId: the item may be a returning product whose
+    // externalId changed. Revive the soft-removed record (preserving addedAt,
+    // shortId and reviews) instead of creating a duplicate that looks new.
+    const revivable = await findRevivableProduct(ctx, args.cafeId, args.name);
+    if (revivable) {
+      return await handleExistingProduct(ctx, args, revivable, now);
     }
 
     return await createNewProduct(ctx, args, now);
@@ -658,6 +695,76 @@ export const markAsRemoved = mutation({
       removedProducts,
       reactivated: reactivatedProducts.length,
       reactivatedProducts,
+    };
+  },
+});
+
+/**
+ * One-time repair for a cafe whose menu was re-imported under a new
+ * `externalId` scheme, which recreated every item with a fresh `addedAt` and
+ * flooded the "new products" list. Backdates the re-imported items to the cafe
+ * creation time so they leave the 30-day new window. Idempotent: items already
+ * older than the target are skipped. Run with `dryRun: true` first to preview.
+ */
+export const backdateReimportedProducts = mutation({
+  args: {
+    cafeSlug: v.string(),
+    // Only affect products added on/before this timestamp (ms). Use it to scope
+    // the fix to the mass-import batch and spare genuinely newer arrivals.
+    importedBefore: v.optional(v.number()),
+    // Timestamp (ms) to backdate matched products to. Defaults to the cafe
+    // creation time; override if that is not comfortably older than 30 days.
+    targetAddedAt: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+    uploadSecret: v.optional(v.string()),
+  },
+  handler: async (
+    ctx,
+    { cafeSlug, importedBefore, targetAddedAt, dryRun, uploadSecret }
+  ) => {
+    verifyUploadSecret(uploadSecret);
+
+    const cafe = await ctx.db
+      .query("cafes")
+      .withIndex("by_slug", (q) => q.eq("slug", cafeSlug))
+      .first();
+    if (!cafe) {
+      throw new Error(`Cafe not found for slug: ${cafeSlug}`);
+    }
+
+    const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const target = targetAddedAt ?? cafe._creationTime;
+    const cutoff = importedBefore ?? Date.now();
+
+    const active = await ctx.db
+      .query("products")
+      .withIndex("by_cafe_active", (q) =>
+        q.eq("cafeId", cafe._id).eq("isActive", true)
+      )
+      .collect();
+
+    // Products currently inside the 30-day "new" window that were (re)created
+    // after the cafe already existed — i.e. the re-import batch, not genuine
+    // launch-day imports (those are already near the cafe creation time).
+    const toBackdate = active.filter(
+      (p) =>
+        p.addedAt >= thirtyDaysAgo && p.addedAt <= cutoff && p.addedAt > target
+    );
+
+    if (!dryRun) {
+      await Promise.all(
+        toBackdate.map((p) => ctx.db.patch(p._id, { addedAt: target }))
+      );
+    }
+
+    return {
+      cafe: cafe.name,
+      dryRun: dryRun ?? false,
+      target,
+      count: toBackdate.length,
+      sample: toBackdate
+        .slice(0, 10)
+        .map((p) => ({ name: p.name, from: p.addedAt })),
     };
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     environment: "node",
     include: [
       "actors/**/*.{test,spec}.{js,ts}",
+      "convex/**/*.{test,spec}.{js,ts}",
       "src/**/*.{test,spec}.{js,ts}",
     ],
     coverage: {


### PR DESCRIPTION
## Problem
Compose Coffee's whole menu shows up as "new". The new-products list is **189/301 (63%) Compose items**, 187 of them stamped with a single `addedAt` = 2026-06-28 — the day the rebuilt Compose crawler (#59) first ran.

Root cause: #59 changed the crawler's `externalId` from `compose_{category}_{name}` to `compose_{item_srl}`. `upsertProduct` matches existing products **only by `externalId`**, so every returning item missed its old record and was recreated fresh via `createNewProduct` (which stamps `addedAt: now`). The old records were soft-removed by `markAsRemoved`. `getRecent`'s only bulk-import guard excludes items added within 24h of *cafe* creation — useless for an established cafe — so all 189 land in the 30-day new window.

## Fix

**Prevention** — `upsertProduct` now, when no product matches by `externalId`, falls back to matching a **soft-removed product in the same cafe by normalized name** and revives it (preserving `addedAt`, `shortId`, and reviews) instead of creating a look-alike. Name normalization folds the hot/iced marker (`HOT `/`ICE ` vs `H-`/`I-`) and whitespace, keeps hot/iced distinct, and only reuses on an **unambiguous single match** so genuinely new drinks are never mis-merged. Pure helper in `convex/productMatching.ts` with unit tests.

**Repair** — `backdateReimportedProducts`: an upload-secret-gated, **idempotent** mutation that backdates a cafe's re-import batch to the cafe creation time, dropping it out of the 30-day window. Supports `dryRun` (preview, no writes) and optional `importedBefore` / `targetAddedAt` scoping.

Also wires `convex/` into the vitest `include` so the new tests run.

## Verification
- `normalizeProductName` unit tests (5) pass; full `tsc --noEmit` clean; `ultracite` clean.
- Root cause confirmed against the live production data (189 Compose items, 187 dated 2026-06-28, numeric `compose_303749`-style externalIds; old name-style records present as soft-removed).

## Deploy / run notes
The repair only takes effect once deployed to production (adamant-turtle-885). After deploy, **dry-run first**:

```bash
curl -s -X POST https://adamant-turtle-885.convex.cloud/api/mutation \
  -H "Content-Type: application/json" \
  -d '{"path":"products:backdateReimportedProducts","format":"json","args":{"cafeSlug":"compose","dryRun":true,"uploadSecret":"<CONVEX_UPLOAD_SECRET>"}}'
```

Confirm `count` (~189) and that `target` is comfortably older than 30 days, then re-run with `"dryRun": false`. To spare the two 2026-07-08 items, add `"importedBefore": 1782658800000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)